### PR TITLE
Kibana dashboard injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ beats_client_beats_packages:
   - metricbeat
 
 beats_client_version: 5.5.0
-beats_client_major_ver: 5.x
+# The apt repo URL pegs minor versions (e.g. 5.x) to avoid unexpected upgrades
+beats_client_major_version_abbreviated: 5.x
 
 beats_client_beats_prereq:
   - apt-transport-https
@@ -39,7 +40,7 @@ beats_client_elastic_pgp_key: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 beats_client_keyserver: pgp.mit.edu
 
 # Elastic's beats debian repository
-beats_client_elastic_repo_url: "deb https://artifacts.elastic.co/packages/{{beats_client_major_ver}}/apt stable main"
+beats_client_elastic_repo_url: "deb https://artifacts.elastic.co/packages/{{ beats_client_major_version_abbreviated }}/apt stable main"
 
 #### FILEBEAT ##################################################################
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ is not enabled by default. You'll need to reference the official beats
 documentation output guides to add those options via variable.
 
 ```yaml
+---
+
 #### PACKAGING #################################################################
 
 # The libbeat packages to install.
@@ -25,6 +27,9 @@ documentation output guides to add those options via variable.
 beats_client_beats_packages:
   - filebeat
   - metricbeat
+
+beats_client_version: 5.5.0
+beats_client_major_ver: 5.x
 
 beats_client_beats_prereq:
   - apt-transport-https
@@ -34,9 +39,10 @@ beats_client_elastic_pgp_key: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 beats_client_keyserver: pgp.mit.edu
 
 # Elastic's beats debian repository
-beats_client_elastic_repo_url: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+beats_client_elastic_repo_url: "deb https://artifacts.elastic.co/packages/{{beats_client_major_ver}}/apt stable main"
 
 #### FILEBEAT ##################################################################
+
 
 # Sane default of localhost. Override to set to the IP address/DNS of the Logstash server.
 beats_client_logserver: "127.0.0.1"
@@ -125,6 +131,20 @@ beats_client_packetbeat_config: {}
 
 #### HEARTBEAT ##################################################################
 beats_client_heartbeat_config: {}
+
+#### KIBANA ##################################################################
+
+beats_client_kibana_export: no
+beats_client_kibana_index: metrics-logstash-*
+beats_client_kibana_url_base: http://localhost:9200
+beats_client_kibana_url: "{{ beats_client_kibana_url_base }}/.kibana"
+beats_client_kibana_indices:
+  metricbeat: metrics-logstash-*
+  filebeat: syslog-*
+beats_client_kibana_dash_search:
+  metricbeat: Metricbeat*
+  filebeat: Filebeat*
+beats_client_kibana_export_parameters: "-only-dashboards -es {{beats_client_kibana_url_base}}"
 
 #### SHARED ##################################################################
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,8 @@ beats_client_beats_packages:
   - metricbeat
 
 beats_client_version: 5.5.0
-beats_client_major_ver: 5.x
+# The apt repo URL pegs minor versions (e.g. 5.x) to avoid unexpected upgrades
+beats_client_major_version_abbreviated: 5.x
 
 beats_client_beats_prereq:
   - apt-transport-https
@@ -19,7 +20,7 @@ beats_client_elastic_pgp_key: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 beats_client_keyserver: pgp.mit.edu
 
 # Elastic's beats debian repository
-beats_client_elastic_repo_url: "deb https://artifacts.elastic.co/packages/{{beats_client_major_ver}}/apt stable main"
+beats_client_elastic_repo_url: "deb https://artifacts.elastic.co/packages/{{ beats_client_major_version_abbreviated }}/apt stable main"
 
 #### FILEBEAT ##################################################################
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,6 +112,20 @@ beats_client_packetbeat_config: {}
 #### HEARTBEAT ##################################################################
 beats_client_heartbeat_config: {}
 
+#### KIBANA ##################################################################
+
+beats_client_kibana_export: no
+beats_client_kibana_index: metrics-logstash-*
+beats_client_kibana_url_base: http://localhost:9200
+beats_client_kibana_url: "{{ beats_client_kibana_url_base }}/.kibana"
+beats_client_kibana_indices:
+  metricbeat: metrics-logstash-*
+  filebeat: syslog-*
+beats_client_kibana_dash_search:
+  metricbeat: Metricbeat*
+  filebeat: Filebeat*
+beats_client_kibana_export_parameters: "-only-dashboards -es {{beats_client_kibana_url_base}}"
+
 #### SHARED ##################################################################
 
 # Note that SSL is disabled here by default, you'll need to override this

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,6 +1,15 @@
 ---
 - hosts: all
+  pre_tasks:
+    - name: Create kibana index
+      uri:
+        url: "{{ beats_client_kibana_url }}"
+        method: PUT
+      changed_when: false
+      ignore_errors: yes
   roles:
     - role: ansible-role-beats
   vars:
     beats_client_logserver: logstash-server
+    beats_client_kibana_url_base: http://esserver:9200
+    beats_client_kibana_export: yes

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -17,11 +17,13 @@ metricbeat_modules = ['cpu',
                       'process',
                       'socket']
 
+beat_dash_type = ['Filebeat*', 'Metricbeat*']
 
-def query_elasticsearch(search, host):
-    curl_cmd = 'curl -s http://esserver:9200/logstash'+search
+
+def query_elasticsearch(search, host, index_name="logstash"):
+    curl_cmd = 'curl -s http://esserver:9200/{}/{}\&pretty'.format(
+                                                            index_name, search)
     elasticsearch_query = host.check_output(curl_cmd)
-    print(elasticsearch_query)
 
     return json.loads(elasticsearch_query)
 
@@ -34,7 +36,7 @@ def test_filebeats(host):
     # dpkg seems to be consistently populated and pushed through since we are
     # doing a lot of package management tasks during the installation of the
     # beats agents
-    search = '/dpkg/_search?q=*\&pretty'
+    search = 'dpkg/_search?q=*'
     results = query_elasticsearch(search, host)
 
     assert results['hits']['total'] != 0
@@ -46,10 +48,18 @@ def test_metricbeats(host, module):
         Ensure metricbeats agent output is making it thru E2E
             metricbeat -> logstash -> elasticsearch
     """
-    # dpkg seems to be consistently populated and pushed through since we are
-    # doing a lot of package management tasks during the installation of the
-    # beats agents
-    search = '/metricsets/_search?q=metricset.name:{}\&pretty'
+    search = 'metricsets/_search?q=metricset.name:{}'
     results = query_elasticsearch(search.format(module), host)
+
+    assert results['hits']['total'] != 0
+
+
+@pytest.mark.parametrize('beat_dashboard_type', beat_dash_type)
+def test_kibana_dashboard_inject(host, beat_dashboard_type):
+    """
+        Ensure beats dashboard injection is making it into elasticsearch
+    """
+    search = '_search?q=title:{}'.format(beat_dashboard_type)
+    results = query_elasticsearch(search, host, index_name=".kibana")
 
     assert results['hits']['total'] != 0

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -1,0 +1,16 @@
+---
+- name: Check for existing dashboards
+  uri:
+    url: "{{beats_client_kibana_url}}/_search?q=title:{{beats_client_kibana_dash_search[item]}}"
+    return_content: yes
+    body_format: json
+    body: {}
+  register: dashboard_check_result
+  changed_when: false
+  ignore_errors: yes
+  with_items: "{{ beats_client_beats_packages }}"
+
+- name: Inject dashboards into kibana index
+  command: /usr/share/{{item}}/scripts/import_dashboards -i {{beats_client_kibana_indices[item]}} {{beats_client_kibana_export_parameters}}
+  when: dashboard_check_result.results[0].json.hits.total == 0
+  with_items: "{{ beats_client_beats_packages }}"

--- a/tasks/kibana.yml
+++ b/tasks/kibana.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check for existing dashboards
   uri:
-    url: "{{beats_client_kibana_url}}/_search?q=title:{{beats_client_kibana_dash_search[item]}}"
+    url: "{{ beats_client_kibana_url }}/_search?q=title:{{ beats_client_kibana_dash_search[item] }}"
     return_content: yes
     body_format: json
     body: {}
@@ -11,6 +11,9 @@
   with_items: "{{ beats_client_beats_packages }}"
 
 - name: Inject dashboards into kibana index
-  command: /usr/share/{{item}}/scripts/import_dashboards -i {{beats_client_kibana_indices[item]}} {{beats_client_kibana_export_parameters}}
+  command: >-
+    /usr/share/{{ item }}/scripts/import_dashboards
+    -i {{ beats_client_kibana_indices[item] }}
+    {{ beats_client_kibana_export_parameters }}
   when: dashboard_check_result.results[0].json.hits.total == 0
   with_items: "{{ beats_client_beats_packages }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,3 +2,7 @@
 - include: packages.yml
 
 - include: configure.yml
+
+- include: kibana.yml
+  tags: kibana
+  when: beats_client_kibana_export


### PR DESCRIPTION
The beats clients have two important elements that are not automatically injected into elasticsearch when you utilize the logstash output:

* es templates for fields
* example dashboards for kibana

There is a script that comes with each beats that will handle this logic. Internally, we are doing template injection in the logstash configs so in a selfish way I made the default here to only import the dashboards. That's easily over-ridden via ansible vars though. Note that since all beats agents might not have write access to ES, you probably only want to run this on a single system that does have ES access (once again controlled via vars). 

How to test? Well first, make sure #19 is merged and accepted since this PR is based off that. Second, if you want to do manual poking:
* Run `molecule converge`
* then `make elastic-ui`
* open a web browser, navigate to localhost:9100, and confirm that you see dashboards injected like so. :

![selection_025](https://user-images.githubusercontent.com/1727935/28215899-986346d0-687d-11e7-8d59-53345397d559.png)

Note that there is a testinfra test that is essentially checking for the same thing that runs in CI so this part isnt mandatory.

