### PR TITLE
Update filebeat config for 7.x compatibility

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ beats_client_filebeat_logging:
     keepfiles: 2
 
 beats_client_filebeat_config:
-  filebeat.prospectors: "{{ beats_client_filebeat_combined_logfiles }}"
+  filebeat.inputs: "{{ beats_client_filebeat_combined_logfiles }}"
   output: "{{ beats_client_output }}"
   logging: "{{ beats_client_filebeat_logging }}"
   setup: "{{ beats_client_filebeat_setup }}"


### PR DESCRIPTION
The config option `filebeat.prospectors` has changed to `filebeat.inputs`, and filebeat will no longer start unless the configuration is updated. [[ref](https://www.elastic.co/blog/brewing-in-beats-rename-filebeat-prospectors-to-inputs)] This simple diff makes that change.