### PR TITLE
Pulls apt key directly from elasticsearch site

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ beats_client_beats_prereq:
 
 # Elastic's PGP key for signing their repository
 beats_client_elastic_pgp_key: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
-beats_client_keyserver: pgp.mit.edu
+beats_client_elastic_gpg_key_url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
 
 # Elastic's beats debian repository
 beats_client_elastic_repo_url: "deb https://artifacts.elastic.co/packages/{{ beats_client_major_version_abbreviated }}/apt stable main"

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -2,7 +2,7 @@
 - name: Add ElasticSearch apt key.
   apt_key:
     id: "{{ beats_client_elastic_pgp_key }}"
-    keyserver: "{{ beats_client_keyserver }}"
+    url: "{{ beats_client_elastic_gpg_key_url }}"
     state: present
 
 - name: Install beats pre-req software


### PR DESCRIPTION
The old pgp.mit.edu keyserver wasn't working reliably, plus HTTPS is a great thing. This change was required when configuring Debian Buster machines recently. 