### PR TITLE
Allow downgrade of beats packages in case they exist in the image already

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -19,4 +19,5 @@
   apt:
     name: "{{ item }}={{ beats_client_version }}"
     state: present
+    allow_downgrade: yes
   with_items: "{{ beats_client_beats_packages }}"


### PR DESCRIPTION
This just adds the `allow_downgrade` flag to the beats installation step -- since we hold that specific version of the package later anyway, this won't cause an issue. This will be pulled into the infra repo's submodules when the `mattermost` branch is merged.